### PR TITLE
Adds MD5 checksums to CMakeLists to avoid unnessary file downloads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,11 +90,16 @@ endif()
 
 # put the boost dependencies for libgusbampapiso64 in the same directory
 set(BOOST_LOCATION https://github.com/sense-base/boost_1_58_0/releases/download/0.0.7)
-file(DOWNLOAD ${BOOST_LOCATION}/libboost_date_time.so.1.58.0 /usr/lib/libboost_date_time.so.1.58.0 EXPECTED_HASH MD5=fdd94573385551381f38b23ea491ec0e)
-file(DOWNLOAD ${BOOST_LOCATION}/libboost_regex.so.1.58.0 /usr/lib/libboost_regex.so.1.58.0 EXPECTED_HASH MD5=3ae740bdce7155732ddd445c8359eb0e)
-file(DOWNLOAD ${BOOST_LOCATION}/libboost_signals.so.1.58.0 /usr/lib/libboost_signals.so.1.58.0 EXPECTED_HASH MD5=45e94dcfc82b223f10ec06946e6a387c)
-file(DOWNLOAD ${BOOST_LOCATION}/libboost_system.so.1.58.0 /usr/lib/libboost_system.so.1.58.0 EXPECTED_HASH MD5=dff3891848d683c62cb1f06ca70718a2)
-file(DOWNLOAD ${BOOST_LOCATION}/libboost_thread.so.1.58.0 /usr/lib/libboost_thread.so.1.58.0 EXPECTED_HASH MD5=73739077c05260017a6abffb39e744d0)
+file(DOWNLOAD ${BOOST_LOCATION}/libboost_date_time.so.1.58.0 /usr/lib/libboost_date_time.so.1.58.0
+  EXPECTED_HASH MD5=fdd94573385551381f38b23ea491ec0e)
+file(DOWNLOAD ${BOOST_LOCATION}/libboost_regex.so.1.58.0 /usr/lib/libboost_regex.so.1.58.0
+  EXPECTED_HASH MD5=3ae740bdce7155732ddd445c8359eb0e)
+file(DOWNLOAD ${BOOST_LOCATION}/libboost_signals.so.1.58.0 /usr/lib/libboost_signals.so.1.58.0
+  EXPECTED_HASH MD5=45e94dcfc82b223f10ec06946e6a387c)
+file(DOWNLOAD ${BOOST_LOCATION}/libboost_system.so.1.58.0 /usr/lib/libboost_system.so.1.58.0
+  EXPECTED_HASH MD5=dff3891848d683c62cb1f06ca70718a2)
+file(DOWNLOAD ${BOOST_LOCATION}/libboost_thread.so.1.58.0 /usr/lib/libboost_thread.so.1.58.0
+  EXPECTED_HASH MD5=73739077c05260017a6abffb39e744d0)
 
 # find dependencies
 find_package(ament_cmake REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,8 @@ set(GTEC_API_LOCATION https://raw.githubusercontent.com/sense-base/PRIVATE_gUSBa
 file(DOWNLOAD
   ${GTEC_API_LOCATION}/gUSBampAPI_1_16_01/gAPI.h
   /usr/include/gAPI.h
-  STATUS DOWNLOAD_STATUS USERPWD $ENV{GTEC_TOKEN})
+  STATUS DOWNLOAD_STATUS USERPWD $ENV{GTEC_TOKEN}
+  EXPECTED_HASH MD5=f1993aea6d7c79e669f84dfd1acb2237)
 
 # Separate the returned status code, and error message.
 list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
@@ -31,7 +32,8 @@ endif()
 file(DOWNLOAD
   ${GTEC_API_LOCATION}/gUSBampAPI_1_16_01/libgUSBampAPIso.so.1.16.01
   /usr/lib/libgUSBampAPIso.so.1.16.01
-  STATUS DOWNLOAD_STATUS USERPWD $ENV{GTEC_TOKEN})
+  STATUS DOWNLOAD_STATUS USERPWD $ENV{GTEC_TOKEN}
+  EXPECTED_HASH MD5=11de08b8b860e227f4597202206327ff)
 
 # Separate the returned status code, and error message.
 list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
@@ -55,7 +57,8 @@ file(MAKE_DIRECTORY /etc/gtec/filter_files)
 file(DOWNLOAD
   ${GTEC_API_LOCATION}/gUSBampAPI_1_16_01/DSPfilter.bin
   /etc/gtec/filter_files/DSPfilter.bin
-  STATUS DOWNLOAD_STATUS USERPWD $ENV{GTEC_TOKEN})
+  STATUS DOWNLOAD_STATUS USERPWD $ENV{GTEC_TOKEN}
+  EXPECTED_HASH MD5=0eb52456f930fd442b31b0f5059a16b2)
 
 # Separate the returned status code, and error message.
 list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
@@ -71,7 +74,8 @@ endif()
 file(DOWNLOAD
   ${GTEC_API_LOCATION}/gUSBampAPI_1_16_01/DSPNotchfilter.bin
   /etc/gtec/filter_files/DSPNotchfilter.bin
-  STATUS DOWNLOAD_STATUS USERPWD $ENV{GTEC_TOKEN})
+  STATUS DOWNLOAD_STATUS USERPWD $ENV{GTEC_TOKEN}
+  EXPECTED_HASH MD5=a72be3241397f52bae4c7285d43145e8)
 
 # Separate the returned status code, and error message.
 list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
@@ -86,11 +90,11 @@ endif()
 
 # put the boost dependencies for libgusbampapiso64 in the same directory
 set(BOOST_LOCATION https://github.com/sense-base/boost_1_58_0/releases/download/0.0.7)
-file(DOWNLOAD ${BOOST_LOCATION}/libboost_date_time.so.1.58.0 /usr/lib/libboost_date_time.so.1.58.0)
-file(DOWNLOAD ${BOOST_LOCATION}/libboost_regex.so.1.58.0 /usr/lib/libboost_regex.so.1.58.0)
-file(DOWNLOAD ${BOOST_LOCATION}/libboost_signals.so.1.58.0 /usr/lib/libboost_signals.so.1.58.0)
-file(DOWNLOAD ${BOOST_LOCATION}/libboost_system.so.1.58.0 /usr/lib/libboost_system.so.1.58.0)
-file(DOWNLOAD ${BOOST_LOCATION}/libboost_thread.so.1.58.0 /usr/lib/libboost_thread.so.1.58.0)
+file(DOWNLOAD ${BOOST_LOCATION}/libboost_date_time.so.1.58.0 /usr/lib/libboost_date_time.so.1.58.0 EXPECTED_HASH MD5=fdd94573385551381f38b23ea491ec0e)
+file(DOWNLOAD ${BOOST_LOCATION}/libboost_regex.so.1.58.0 /usr/lib/libboost_regex.so.1.58.0 EXPECTED_HASH MD5=3ae740bdce7155732ddd445c8359eb0e)
+file(DOWNLOAD ${BOOST_LOCATION}/libboost_signals.so.1.58.0 /usr/lib/libboost_signals.so.1.58.0 EXPECTED_HASH MD5=45e94dcfc82b223f10ec06946e6a387c)
+file(DOWNLOAD ${BOOST_LOCATION}/libboost_system.so.1.58.0 /usr/lib/libboost_system.so.1.58.0 EXPECTED_HASH MD5=dff3891848d683c62cb1f06ca70718a2)
+file(DOWNLOAD ${BOOST_LOCATION}/libboost_thread.so.1.58.0 /usr/lib/libboost_thread.so.1.58.0 EXPECTED_HASH MD5=73739077c05260017a6abffb39e744d0)
 
 # find dependencies
 find_package(ament_cmake REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,9 @@ endif()
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-# Download some of our dependencies
+# Download dependencies. For g.tec drivers we use status codes to check for download success,
+# as these are likely to go wrong if there is an error with GTEC_TOKEN.
+# We use the EXPECTED_HASH option to check if the file is already present to avoid unnecessary repeat downloads.
 
 set(GTEC_API_LOCATION https://raw.githubusercontent.com/sense-base/PRIVATE_gUSBamp-Linux-Driver-C-API/refs/heads/main)
 
@@ -88,7 +90,7 @@ else()
   message(FATAL_ERROR "Error occurred during download of gAPI.h: ${ERROR_MESSAGE}")
 endif()
 
-# put the boost dependencies for libgusbampapiso64 in the same directory
+# Get the boost dependencies for libgusbampapiso64
 set(BOOST_LOCATION https://github.com/sense-base/boost_1_58_0/releases/download/0.0.7)
 file(DOWNLOAD ${BOOST_LOCATION}/libboost_date_time.so.1.58.0 /usr/lib/libboost_date_time.so.1.58.0
   EXPECTED_HASH MD5=fdd94573385551381f38b23ea491ec0e)
@@ -106,10 +108,6 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(eeg_msgs REQUIRED)
-
-# uncomment the following section in order to fill in
-# further dependencies manually.
-# find_package(<dependency> REQUIRED)
 
 add_executable(gtec_eeg_publisher src/sense_eeg.cpp)
 ament_target_dependencies(gtec_eeg_publisher rclcpp std_msgs eeg_msgs)


### PR DESCRIPTION
By adding the MD5 checksums to the file downloads we avoid downloading the dependencies if they are already present on the file system. Should slightly speed up CI testing and development.